### PR TITLE
Update namespace and init method.

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,10 +17,8 @@ composer require builtnorth/wp-environment-indicator
 Initialize the plugin in your theme or plugin:
 
 ```php
-use WPEnvironmentIndicator\App;
-
-$indicator = new App();
-$indicator->init();
+$indicator = new BuiltNorth\WPEnvironmentIndicator\App();
+$indicator->boot();
 ```
 
 ### Custom Configuration
@@ -49,16 +47,16 @@ $indicator->init();
 
 ## Features
 
--   Automatically detects environment using `WP_ENVIRONMENT_TYPE`
--   Shows environment indicator in admin bar
--   Customizable colors and labels
--   Only visible to users with `manage_options` capability
--   Lightweight and efficient
+- Automatically detects environment using `WP_ENVIRONMENT_TYPE`
+- Shows environment indicator in admin bar
+- Customizable colors and labels
+- Only visible to users with `manage_options` capability
+- Lightweight and efficient
 
 ## Requirements
 
--   PHP 8.0 or higher
--   WordPress 5.0 or higher
+- PHP 8.0 or higher
+- WordPress 5.0 or higher
 
 ## License
 

--- a/composer.json
+++ b/composer.json
@@ -2,10 +2,11 @@
 	"name": "builtnorth/wp-environment-indicator",
 	"description": "A simple WordPress environment indicator for the admin bar",
 	"type": "library",
+	"version": "1.0.0",
 	"license": "GPL-2.0-or-later",
 	"autoload": {
 		"psr-4": {
-			"WPEnvironmentIndicator\\": "inc/"
+			"BuiltNorth\\WPEnvironmentIndicator\\": "inc/"
 		}
 	},
 	"authors": [

--- a/inc/App.php
+++ b/inc/App.php
@@ -14,15 +14,15 @@ class App
 	 */
 	private array $config = [
 		'development' => [
-			'color' => '#4f9fe4',
+			'color' => '#3858e9',
 			'text' => 'Development'
 		],
 		'staging' => [
-			'color' => '#e38a1e',
+			'color' => '#db7800',
 			'text' => 'Staging'
 		],
 		'production' => [
-			'color' => '#82cd2a',
+			'color' => '#0cb034',
 			'text' => 'Production'
 		]
 	];
@@ -99,9 +99,10 @@ class App
 
 			#wpadminbar #wp-admin-bar-environment-indicator .env-dot {
 				display: inline-block;
-				width: 8px;
-				height: 8px;
+				width: 6px;
+				height: 6px;
 				border-radius: 50%;
+				border: 1px solid #ffffff;
 				background: <?php echo esc_attr($config['color']); ?>;
 				margin-right: 2px;
 				margin-top: -2px;

--- a/inc/App.php
+++ b/inc/App.php
@@ -1,9 +1,16 @@
 <?php
 
-namespace WPEnvironmentIndicator;
+namespace BuiltNorth\WPEnvironmentIndicator;
 
 class App
 {
+	/**
+	 * Holds the single instance of this class.
+	 *
+	 * @var App|null
+	 */
+	protected static $instance = null;
+
 	/**
 	 * @var string The current environment
 	 */
@@ -28,9 +35,32 @@ class App
 	];
 
 	/**
-	 * Initialize the plugin
+	 * Get the single instance of this class.
+	 *
+	 * @return App
 	 */
-	public function init(): void
+	public static function instance()
+	{
+		if (is_null(self::$instance)) {
+			self::$instance = new self();
+		}
+		return self::$instance;
+	}
+
+	/**
+	 * Private constructor to prevent direct instantiation.
+	 */
+	private function __construct()
+	{
+		// Constructor does nothing - initialization happens in boot()
+	}
+
+
+	/**
+	 * Boot the environment indicator.
+	 * This method should be called after getting the instance.
+	 */
+	public function boot(): void
 	{
 		$this->environment = $this->detect_environment();
 


### PR DESCRIPTION
BREAKING CHANGE:

now uses:
```php
$indicator = new BuiltNorth\WPEnvironmentIndicator\App();
$indicator->boot();
```
instead of:
```php
$indicator = new WPEnvironmentIndicator\App();
$indicator->init();
```